### PR TITLE
fix: more ui bugs

### DIFF
--- a/server/redact.ts
+++ b/server/redact.ts
@@ -63,7 +63,6 @@ export function redactStateForPlayer(
     attackRerollsRemaining: state.attackRerollsRemaining,
     diceBank: state.diceBank,
     winningPlayerIndex: state.winningPlayerIndex,
-    buildContext: state.buildContext,
     pendingBuildCardID: state.pendingBuildCardID,
     log: redactLog(state.log, viewerIdx),
   }

--- a/src/common/IGameState.ts
+++ b/src/common/IGameState.ts
@@ -49,7 +49,6 @@ export default interface IGameState {
 
   winningPlayerIndex: number | undefined
 
-  buildContext?: { cardID: string; fortID?: string }
   pendingBuildCardID?: string
 
   log: ILogEntry[]

--- a/src/common/IGameStateView.ts
+++ b/src/common/IGameStateView.ts
@@ -40,7 +40,6 @@ export default interface IGameStateView {
   attackRerollsRemaining: number
   diceBank: rollCounts
   winningPlayerIndex: number | undefined
-  buildContext?: { cardID: string; fortID?: string }
   pendingBuildCardID?: string
   log: ILogEntry[]
 }

--- a/src/common/handlers/action.ts
+++ b/src/common/handlers/action.ts
@@ -16,7 +16,6 @@ export function handleAction(
   const action = payload.actionChosen
   const base = {
     ...state,
-    buildContext: undefined,
     pendingBuildCardID: payload.cardID,
   }
   switch (action) {

--- a/src/common/handlers/buildBuilding.ts
+++ b/src/common/handlers/buildBuilding.ts
@@ -37,7 +37,6 @@ export function handleBuildBuilding(
     ...state,
     players,
     phase: 'endTurn',
-    buildContext: { cardID: payload.buildingID, fortID: payload.fortID },
     pendingBuildCardID: undefined,
     log: [...state.log, logEntry],
   }

--- a/src/common/handlers/buildFort.ts
+++ b/src/common/handlers/buildFort.ts
@@ -63,7 +63,6 @@ export function handleBuildFort(
     ...state,
     players,
     phase: 'endTurn',
-    buildContext: { cardID: payload.fortID },
     pendingBuildCardID: undefined,
     log: [...state.log, logEntry],
   }

--- a/src/common/handlers/buildShip.ts
+++ b/src/common/handlers/buildShip.ts
@@ -33,7 +33,6 @@ export function handleBuildShip(
     ...state,
     players,
     phase: 'endTurn',
-    buildContext: { cardID: payload.shipID, fortID: payload.fortID },
     pendingBuildCardID: undefined,
     log: [...state.log, logEntry],
   }

--- a/src/components/ActionSelector.tsx
+++ b/src/components/ActionSelector.tsx
@@ -262,12 +262,12 @@ const ActionSelector: React.FC<ActionSelectorProps> = ({
                       flexWrap: 'wrap',
                       alignItems: 'flex-start',
                     }}>
-                    <Fort fort={t.fort} />
+                    <Fort fort={t.fort} color={t.playerColor} />
                     {t.fort.buildings.map(b => (
-                      <Building key={b.id} building={b} />
+                      <Building key={b.id} building={b} color={t.playerColor} />
                     ))}
                     {t.playerShips.map(s => (
-                      <Ship key={s.id} ship={s} />
+                      <Ship key={s.id} ship={s} color={t.playerColor} />
                     ))}
                   </div>
                 </div>

--- a/src/components/ActionSelector.tsx
+++ b/src/components/ActionSelector.tsx
@@ -67,6 +67,9 @@ const ActionSelector: React.FC<ActionSelectorProps> = ({
   const showShipPicker = activePicker === 'ship'
 
   function togglePicker(p: Picker) {
+    // re-opening a picker also backs out of any in-progress fort selection
+    setPendingBuildAction(null)
+    setPendingRepairFort(null)
     setActivePicker(v => (v === p ? null : p))
   }
   const [pendingBuildAction, setPendingBuildAction] = useState<{
@@ -341,8 +344,28 @@ const ActionSelector: React.FC<ActionSelectorProps> = ({
             <strong>{pendingBuildAction.card.name}</strong> at (requires{' '}
             {pendingBuildAction.card.cost} colonists):
           </p>
-          {pendingBuildAction.action === 'buildBuilding' &&
-          !pendingRepairFort ? (
+          {pendingRepairFort ? (
+            <div>
+              <p style={{ marginBottom: 8 }}>
+                <DescriptionText
+                  text={`Place the repair shell ${
+                    pendingBuildAction.card.repair?.[0]
+                      ? `[${colorToSymbol(pendingBuildAction.card.repair[0])}]`
+                      : ''
+                  }`}
+                />
+              </p>
+              <FortGrid
+                grid={pendingRepairFort.grid}
+                view="tableau"
+                showLabels
+                highlights={shellInfo(pendingRepairFort.grid)
+                  .filter(s => s.color === null)
+                  .map(s => s.loc)}
+                onCellClick={handleRepairCellPicked}
+              />
+            </div>
+          ) : (
             <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
               {forts.map(fort => {
                 const ok =
@@ -368,62 +391,12 @@ const ActionSelector: React.FC<ActionSelectorProps> = ({
                       ;(e.currentTarget as HTMLDivElement).style.outlineColor =
                         'transparent'
                     }}>
-                    <Fort fort={fort} />
+                    <Fort fort={fort} color={player.color} />
                   </div>
                 )
               })}
             </div>
-          ) : pendingBuildAction.action === 'buildBuilding' &&
-            pendingRepairFort ? (
-            <div>
-              <p style={{ marginBottom: 8 }}>
-                <DescriptionText
-                  text={`Place the repair shell ${
-                    pendingBuildAction.card.repair?.[0]
-                      ? `[${colorToSymbol(pendingBuildAction.card.repair[0])}]`
-                      : ''
-                  }`}
-                />
-              </p>
-              <FortGrid
-                grid={pendingRepairFort.grid}
-                view="tableau"
-                showLabels
-                highlights={shellInfo(pendingRepairFort.grid)
-                  .filter(s => s.color === null)
-                  .map(s => s.loc)}
-                onCellClick={handleRepairCellPicked}
-              />
-            </div>
-          ) : (
-            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-              {forts.map(fort => {
-                const ok =
-                  pendingBuildAction.card.cost !== undefined &&
-                  fort.usedSlots >= pendingBuildAction.card.cost
-                return (
-                  <button
-                    key={fort.id}
-                    onClick={() => ok && handleFortPicked(fort)}
-                    disabled={!ok}
-                    style={{ opacity: ok ? 1 : 0.4 }}>
-                    {fort.name} — {fort.usedSlots}/{fort.slots}
-                  </button>
-                )
-              })}
-            </div>
           )}
-          <button
-            onClick={() => {
-              if (pendingRepairFort) {
-                setPendingRepairFort(null)
-              } else {
-                setPendingBuildAction(null)
-              }
-            }}
-            style={{ marginTop: 10 }}>
-            ← Back
-          </button>
         </div>
       )}
     </div>

--- a/src/components/Building.tsx
+++ b/src/components/Building.tsx
@@ -1,51 +1,36 @@
 import React from 'react'
 import IBuilding from 'common/IBuilding'
-import DescriptionText from 'components/DescriptionText'
+import TableauCard from './TableauCard'
+import Pips from './Pips'
 
 interface BuildingProps {
   building: IBuilding
   preview?: boolean
   highlighted?: boolean
+  // full width, half height — stacked beside its fort
+  compact?: boolean
+  // owning player's color — tints the colonist meeples
+  color?: string
 }
 
 const Building: React.FC<BuildingProps> = ({
   building,
   preview,
   highlighted,
+  compact,
+  color,
 }) => (
-  <div
-    style={{
-      border: highlighted ? '1px solid #aac' : '1px solid #aaa',
-      borderRadius: 6,
-      padding: 8,
-      marginBottom: 8,
-      background: highlighted ? '#f0f4ff' : '#fff',
-      transition: 'background 0.15s, border-color 0.15s',
-    }}>
-    <strong>{building.name}</strong>
-    <div style={{ fontSize: 13, color: '#555', margin: '4px 0' }}>
-      <DescriptionText text={building.description} />
-    </div>
+  <TableauCard
+    title={building.name}
+    description={building.description}
+    highlighted={highlighted}
+    compact={compact}>
     {preview ? (
-      <div style={{ fontSize: 13 }}>Cost: {building.cost} colonists</div>
+      <div className="tableau-card-cost">Cost: {building.cost} colonists</div>
     ) : (
-      <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
-        {Array.from({ length: building.colonists }).map((_, i) => (
-          <div
-            key={i}
-            style={{
-              width: 14,
-              height: 14,
-              borderRadius: '50%',
-              border: '2px solid #888',
-              background: '#f1c40f',
-              boxSizing: 'border-box',
-            }}
-          />
-        ))}
-      </div>
+      <Pips count={building.colonists} color={color} />
     )}
-  </div>
+  </TableauCard>
 )
 
 export default Building

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -8,7 +8,7 @@ import MeepleIcon from 'components/MeepleIcon'
 import CoinIcon from 'components/CoinIcon'
 import HammerIcon from 'components/HammerIcon'
 import DescriptionText from 'components/DescriptionText'
-import './shared.css'
+import './styles.css'
 
 interface CardProps {
   card: ICard

--- a/src/components/CardInfoPopover.tsx
+++ b/src/components/CardInfoPopover.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react'
-import './shared.css'
+import './styles.css'
 
 interface CardInfoPopoverProps {
   info: string

--- a/src/components/CardInfoPopover.tsx
+++ b/src/components/CardInfoPopover.tsx
@@ -1,0 +1,48 @@
+import React, { useState, useRef, useEffect } from 'react'
+import './shared.css'
+
+interface CardInfoPopoverProps {
+  info: string
+  // applied to the wrapper so it can carry the card's flex sizing
+  style?: React.CSSProperties
+  children: React.ReactNode
+}
+
+// Wraps a tableau card; clicking it toggles a styled info popover (card type,
+// colonists, buildings). Closes on a click outside or Escape.
+const CardInfoPopover: React.FC<CardInfoPopoverProps> = ({
+  info,
+  style,
+  children,
+}) => {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <div
+      ref={ref}
+      style={{ ...style, position: 'relative', cursor: 'pointer' }}
+      onClick={() => setOpen(o => !o)}>
+      {children}
+      {open && <div className="card-info-popover">{info}</div>}
+    </div>
+  )
+}
+
+export default CardInfoPopover

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import './shared.css'
+import './styles.css'
 
 interface Color {
   name: string

--- a/src/components/Deck.tsx
+++ b/src/components/Deck.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import './shared.css'
+import './styles.css'
 
 interface DeckProps {
   count: number

--- a/src/components/Fort.tsx
+++ b/src/components/Fort.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
 import IFort from 'common/IFort'
 import FortGrid from './FortGrid'
-import DescriptionText from 'components/DescriptionText'
+import TableauCard from './TableauCard'
+import Pips from './Pips'
 
 interface FortProps {
   fort: IFort
   // highlighted by an enclosing group (e.g. hover) — fort and its buildings light up together
   highlighted?: boolean
+  // owning player's color — tints the colonist meeples
+  color?: string
   // interactive grid props — when provided the grid becomes clickable (e.g. wave phases)
   highlights?: [number, number][]
   dims?: [number, number][]
@@ -17,45 +20,17 @@ interface FortProps {
 const Fort: React.FC<FortProps> = ({
   fort,
   highlighted,
+  color,
   highlights,
   dims,
   selectedGroup,
   onCellClick,
 }) => (
-  <div
-    style={{
-      border: highlighted ? '1px solid #aac' : '1px solid #888',
-      borderRadius: 6,
-      padding: 8,
-      marginBottom: 8,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      background: highlighted ? '#f0f4ff' : '#fff',
-      transition: 'background 0.15s, border-color 0.15s',
-    }}>
-    <strong>{fort.name}</strong>
-    <div
-      style={{
-        whiteSpace: 'pre-line',
-        wordBreak: 'break-word',
-        fontFamily: 'Georgia, serif',
-        fontSize: 13,
-        lineHeight: 1.35,
-        color: '#555',
-        marginBottom: 6,
-        textAlign: 'center',
-        // fixed width + reserved height so every fort wraps identically and
-        // cards align in height regardless of an attached building's pressure
-        width: 200,
-        minHeight: 74,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}>
-      <DescriptionText text={fort.description} />
-    </div>
-    <div style={{ margin: '8px 0' }}>
+  <TableauCard
+    title={fort.name}
+    description={fort.description}
+    highlighted={highlighted}>
+    <div className="tableau-card-grid">
       <FortGrid
         grid={fort.grid}
         view="tableau"
@@ -66,30 +41,8 @@ const Fort: React.FC<FortProps> = ({
         onCellClick={onCellClick}
       />
     </div>
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        gap: 8,
-        marginTop: 8,
-      }}>
-      {Array.from({ length: fort.slots }).map((_, i) => (
-        <div
-          key={i}
-          style={{
-            width: 18,
-            height: 18,
-            borderRadius: '50%',
-            border: '2px solid #888',
-            background: i < fort.usedSlots ? '#f1c40f' : '#fff',
-            boxSizing: 'border-box',
-            transition: 'background 0.2s',
-          }}
-          title={i < fort.usedSlots ? 'Occupied' : 'Empty'}
-        />
-      ))}
-    </div>
-  </div>
+    <Pips count={fort.slots} filled={fort.usedSlots} color={color} />
+  </TableauCard>
 )
 
 export default Fort

--- a/src/components/FortGrid.tsx
+++ b/src/components/FortGrid.tsx
@@ -57,20 +57,39 @@ export const FortGrid: React.FC<{
             const isClickable = isHighlight && !!onCellClick
 
             let bgColor = '#99bed8'
-            let border = '3px solid #925b24'
+            let border = '3px solid #99bed8'
             if (cell.type === 'shell') {
               if (view === 'hand') {
-                bgColor = cell.color ? ShellColors[cell.color] : '#a0785a'
+                bgColor = cell.color ? ShellColors[cell.color] : '#f5e6c8'
               } else if (view === 'tableau') {
-                bgColor = cell.color ? ShellColors[cell.color] : '#a0785a'
+                bgColor = cell.color ? ShellColors[cell.color] : '#f5e6c8'
               }
-            } else {
-              border = '3px solid #fff'
+              border = `3px solid ${cell.color ? ShellColors[cell.color] : '#f5e6c8'}`
             }
 
             if (isHighlight) border = '3px solid #27ae60'
             if (isDim) border = '3px solid #999'
             if (selectedSet.has(key)) border = '3px solid #e74c3c'
+
+            const isShell = cell.type === 'shell'
+            const neighborIsNaC = (r: number, c: number) =>
+              r < 0 ||
+              r >= grid.length ||
+              c < 0 ||
+              c >= grid[0].length ||
+              grid[r][c].type !== 'shell'
+            const outlineColor = '#925b24'
+            const edgeColor = (r: number, c: number) =>
+              neighborIsNaC(r, c) ? outlineColor : bgColor
+            const shapeOutline =
+              isShell && !isHighlight && !isDim && !selectedSet.has(key)
+                ? {
+                    borderTopColor: edgeColor(rowIndex - 1, colIndex),
+                    borderRightColor: edgeColor(rowIndex, colIndex + 1),
+                    borderBottomColor: edgeColor(rowIndex + 1, colIndex),
+                    borderLeftColor: edgeColor(rowIndex, colIndex - 1),
+                  }
+                : {}
 
             return (
               <div
@@ -84,6 +103,7 @@ export const FortGrid: React.FC<{
                 style={{
                   backgroundColor: bgColor,
                   border,
+                  ...shapeOutline,
                   opacity: isDim ? 0.4 : 1,
                   cursor: isClickable ? 'pointer' : 'default',
                   color: getLabelTextColor(cell),

--- a/src/components/FortGrid.tsx
+++ b/src/components/FortGrid.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { FortGridCell } from 'common/fortGrid'
 import { ShellColors } from '../common/colors'
-import './shared.css'
+import './styles.css'
 
 function getCellLabel(cell: FortGridCell) {
   if (cell.type === 'shell' && cell.color) return cell.color[0].toUpperCase()

--- a/src/components/FortGroup.tsx
+++ b/src/components/FortGroup.tsx
@@ -4,6 +4,8 @@ import IBuilding from 'common/IBuilding'
 import Fort from './Fort'
 import Building from './Building'
 import PlayerShip from './PlayerShip'
+import CardInfoPopover from './CardInfoPopover'
+import { fortTooltip, buildingTooltip } from './cardTooltip'
 
 interface AttackingShip {
   color?: string
@@ -59,9 +61,9 @@ const FortGroup: React.FC<FortGroupProps> = ({
         </div>
       )}
       {/* the fort defines the group height */}
-      <div style={{ flexShrink: 0 }}>
+      <CardInfoPopover info={fortTooltip(fort)} style={{ flexShrink: 0 }}>
         <Fort fort={fort} highlighted={hovered} color={color} />
-      </div>
+      </CardInfoPopover>
       {/* the column stretches to the fort's height; each building takes an even
           share capped at half, so two split the height and a lone building
           stays half-height — no fort growth or measurement needed */}
@@ -73,8 +75,9 @@ const FortGroup: React.FC<FortGroupProps> = ({
             gap: 4,
           }}>
           {buildings.map(building => (
-            <div
+            <CardInfoPopover
               key={building.id}
+              info={buildingTooltip(building)}
               style={{ flex: 1, minHeight: 0, maxHeight: '50%' }}>
               <Building
                 building={building}
@@ -82,7 +85,7 @@ const FortGroup: React.FC<FortGroupProps> = ({
                 compact
                 color={color}
               />
-            </div>
+            </CardInfoPopover>
           ))}
         </div>
       )}

--- a/src/components/FortGroup.tsx
+++ b/src/components/FortGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useLayoutEffect } from 'react'
+import React, { useState } from 'react'
 import IFort from 'common/IFort'
 import IBuilding from 'common/IBuilding'
 import Fort from './Fort'
@@ -14,29 +14,17 @@ interface FortGroupProps {
   fort: IFort
   buildings: IBuilding[]
   attackingShips: AttackingShip[]
+  // owning player's color — tints the colonist meeples
+  color?: string
 }
 
 const FortGroup: React.FC<FortGroupProps> = ({
   fort,
   buildings,
   attackingShips,
+  color,
 }) => {
   const [hovered, setHovered] = useState(false)
-  const fortRef = useRef<HTMLDivElement>(null)
-  const [buildingSize, setBuildingSize] = useState<{
-    w: number
-    h: number
-  } | null>(null)
-
-  useLayoutEffect(() => {
-    if (fortRef.current) {
-      const w = fortRef.current.offsetWidth / 2
-      const h = fortRef.current.offsetHeight / 2
-      setBuildingSize(prev =>
-        prev?.w === w && prev?.h === h ? prev : { w, h },
-      )
-    }
-  }, [fort.id])
 
   return (
     <div
@@ -46,7 +34,7 @@ const FortGroup: React.FC<FortGroupProps> = ({
         position: 'relative',
         display: 'flex',
         flexDirection: 'row',
-        alignItems: 'flex-start',
+        alignItems: 'stretch',
         gap: 6,
         padding: 6,
       }}>
@@ -70,23 +58,30 @@ const FortGroup: React.FC<FortGroupProps> = ({
           ))}
         </div>
       )}
-      <div ref={fortRef} style={{ flexShrink: 0 }}>
-        <Fort fort={fort} highlighted={hovered} />
+      {/* the fort defines the group height */}
+      <div style={{ flexShrink: 0 }}>
+        <Fort fort={fort} highlighted={hovered} color={color} />
       </div>
-      {buildings.length > 0 && buildingSize && (
+      {/* the column stretches to the fort's height; each building takes an even
+          share capped at half, so two split the height and a lone building
+          stays half-height — no fort growth or measurement needed */}
+      {buildings.length > 0 && (
         <div
           style={{
             display: 'flex',
             flexDirection: 'column',
-            flexWrap: 'wrap',
-            maxHeight: buildingSize.h * 2,
             gap: 4,
           }}>
           {buildings.map(building => (
             <div
               key={building.id}
-              style={{ width: buildingSize.w, flexShrink: 0 }}>
-              <Building building={building} highlighted={hovered} />
+              style={{ flex: 1, minHeight: 0, maxHeight: '50%' }}>
+              <Building
+                building={building}
+                highlighted={hovered}
+                compact
+                color={color}
+              />
             </div>
           ))}
         </div>

--- a/src/components/GameShell.tsx
+++ b/src/components/GameShell.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import './shared.css'
+import { sectionLabel } from './styles'
 import IGameStateView from 'common/IGameStateView'
 import ICard from 'common/ICard'
 import { TurnBanner, WaitingForPlayer } from './TurnBanner'
@@ -68,9 +68,7 @@ const GameShell: React.FC<GameShellProps> = ({
               borderBottom: '1px solid #ddd',
               overflowX: 'auto',
             }}>
-            <div className="section-label" style={{ marginBottom: 8 }}>
-              Your Hand
-            </div>
+            <div style={{ ...sectionLabel, marginBottom: 8 }}>Your Hand</div>
             <Hand cards={handCards} />
           </div>
         )}

--- a/src/components/GameShell.tsx
+++ b/src/components/GameShell.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import './shared.css'
 import IGameStateView from 'common/IGameStateView'
 import ICard from 'common/ICard'
 import { TurnBanner, WaitingForPlayer } from './TurnBanner'
@@ -67,13 +68,7 @@ const GameShell: React.FC<GameShellProps> = ({
               borderBottom: '1px solid #ddd',
               overflowX: 'auto',
             }}>
-            <div
-              style={{
-                fontWeight: 600,
-                fontSize: 13,
-                color: '#666',
-                marginBottom: 8,
-              }}>
+            <div className="section-label" style={{ marginBottom: 8 }}>
               Your Hand
             </div>
             <Hand cards={handCards} />

--- a/src/components/GameShell.tsx
+++ b/src/components/GameShell.tsx
@@ -12,7 +12,6 @@ interface GameShellProps {
   playerIdx: number
   isMyTurn: boolean
   waitingFor: WaitingForPlayer[]
-  buildContext?: { cardID: string; fortID?: string }
   actionContent: React.ReactNode
   logOpen: boolean
   onToggleLog: () => void
@@ -23,7 +22,6 @@ const GameShell: React.FC<GameShellProps> = ({
   playerIdx,
   isMyTurn,
   waitingFor,
-  buildContext,
   actionContent,
   logOpen,
   onToggleLog,
@@ -44,7 +42,6 @@ const GameShell: React.FC<GameShellProps> = ({
           phase={view.phase}
           isMyTurn={isMyTurn}
           waitingFor={waitingFor}
-          buildContext={buildContext}
           logOpen={logOpen}
           onToggleLog={onToggleLog}
         />

--- a/src/components/Hand.tsx
+++ b/src/components/Hand.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Card from './Card'
 import ICard from 'common/ICard'
-import './shared.css'
+import './styles.css'
 
 interface HandProps {
   cards: ICard[]

--- a/src/components/Pips.tsx
+++ b/src/components/Pips.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import MeepleIcon from './MeepleIcon'
-import './shared.css'
+import './styles.css'
 
 interface PipsProps {
   count: number

--- a/src/components/Pips.tsx
+++ b/src/components/Pips.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import MeepleIcon from './MeepleIcon'
+import './shared.css'
+
+interface PipsProps {
+  count: number
+  // number of filled pips; defaults to all filled. When given, the unfilled
+  // pips render as empty slots with Occupied/Empty titles (fort slots).
+  filled?: number
+  // colonist (meeple) color — the owning player's color
+  color?: string
+}
+
+// Colonist pips shared by Fort (slots), Ship and Building (cost). Filled pips
+// show a colonist meeple over the slot; unfilled pips are empty slot outlines.
+const Pips: React.FC<PipsProps> = ({ count, filled, color }) => {
+  const filledCount = filled ?? count
+  const labeled = filled !== undefined
+
+  return (
+    <div className="tableau-card-pips">
+      {Array.from({ length: count }).map((_, i) => {
+        const isFilled = i < filledCount
+        return (
+          <div
+            key={i}
+            className={`tableau-card-pip${isFilled ? ' filled' : ''}`}
+            title={labeled ? (isFilled ? 'Occupied' : 'Empty') : undefined}>
+            {isFilled && <MeepleIcon size={14} color={color} />}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default Pips

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import './shared.css'
+import './styles.css'
 
 interface PlayerProps {
   children?: React.ReactNode

--- a/src/components/Ship.tsx
+++ b/src/components/Ship.tsx
@@ -1,44 +1,35 @@
 import React from 'react'
 import IShip from 'common/IShip'
-import DescriptionText from 'components/DescriptionText'
+import TableauCard from './TableauCard'
+import Pips from './Pips'
 
 interface ShipProps {
   ship: IShip
   preview?: boolean
+  highlighted?: boolean
+  fill?: boolean
+  // owning player's color — tints the colonist meeples
+  color?: string
 }
 
-const Ship: React.FC<ShipProps> = ({ ship, preview }) => (
-  <div
-    style={{
-      border: '1px solid #55a',
-      borderRadius: 6,
-      padding: 8,
-      marginBottom: 8,
-    }}>
-    <strong>{ship.name}</strong>
-    <div style={{ fontSize: 13, color: '#555', margin: '4px 0' }}>
-      <DescriptionText text={ship.description} />
-    </div>
+const Ship: React.FC<ShipProps> = ({
+  ship,
+  preview,
+  highlighted,
+  fill,
+  color,
+}) => (
+  <TableauCard
+    title={ship.name}
+    description={ship.description}
+    highlighted={highlighted}
+    fill={fill}>
     {preview ? (
-      <div style={{ fontSize: 13 }}>Cost: {ship.cost} colonists</div>
+      <div className="tableau-card-cost">Cost: {ship.cost} colonists</div>
     ) : (
-      <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
-        {Array.from({ length: ship.colonists }).map((_, i) => (
-          <div
-            key={i}
-            style={{
-              width: 14,
-              height: 14,
-              borderRadius: '50%',
-              border: '2px solid #888',
-              background: '#f1c40f',
-              boxSizing: 'border-box',
-            }}
-          />
-        ))}
-      </div>
+      <Pips count={ship.colonists} color={color} />
     )}
-  </div>
+  </TableauCard>
 )
 
 export default Ship

--- a/src/components/TableauCard.tsx
+++ b/src/components/TableauCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import DescriptionText from 'components/DescriptionText'
-import './shared.css'
+import './styles.css'
 
 interface TableauCardProps {
   title: string

--- a/src/components/TableauCard.tsx
+++ b/src/components/TableauCard.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import DescriptionText from 'components/DescriptionText'
+import './shared.css'
+
+interface TableauCardProps {
+  title: string
+  description: string
+  // forts/buildings highlight as a group; ships individually
+  highlighted?: boolean
+  // full width, half height — buildings stacked beside their fort
+  compact?: boolean
+  // stretch to the row height (e.g. ships matching fort height)
+  fill?: boolean
+  // body between the description and the footer (grid, pips, cost, …)
+  children?: React.ReactNode
+}
+
+// Shared chrome for the in-play cards (Fort, Ship, Building): border/layout via
+// .tableau-card, a title, the description block, then card-specific children.
+const TableauCard: React.FC<TableauCardProps> = ({
+  title,
+  description,
+  highlighted,
+  compact,
+  fill,
+  children,
+}) => {
+  const cls = [
+    'tableau-card',
+    highlighted && 'highlighted',
+    compact && 'compact',
+    fill && 'fill',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div className={cls}>
+      <strong>{title}</strong>
+      <div className="tableau-card-description">
+        <DescriptionText text={description} />
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export default TableauCard

--- a/src/components/TableauPanel.tsx
+++ b/src/components/TableauPanel.tsx
@@ -3,6 +3,8 @@ import IGameStateView from 'common/IGameStateView'
 import IShip from 'common/IShip'
 import FortGroup from './FortGroup'
 import Ship from './Ship'
+import CardInfoPopover from './CardInfoPopover'
+import { shipTooltip } from './cardTooltip'
 import { rotateFrom } from 'common/order'
 import PlayerShip from './PlayerShip'
 
@@ -23,7 +25,9 @@ const ShipCard: React.FC<{ ship: IShip; color?: string }> = ({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{ display: 'flex', padding: 6 }}>
-      <Ship ship={ship} highlighted={hovered} fill color={color} />
+      <CardInfoPopover info={shipTooltip(ship)} style={{ display: 'flex' }}>
+        <Ship ship={ship} highlighted={hovered} fill color={color} />
+      </CardInfoPopover>
     </div>
   )
 }

--- a/src/components/TableauPanel.tsx
+++ b/src/components/TableauPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import './shared.css'
+import { sectionLabel } from './styles'
 import IGameStateView from 'common/IGameStateView'
 import IShip from 'common/IShip'
 import FortGroup from './FortGroup'
@@ -77,7 +77,7 @@ const TableauPanel: React.FC<TableauPanelProps> = ({ view, playerIdx }) => {
                 marginBottom: 8,
               }}>
               {i === playerIdx ? (
-                <span className="section-label">Your Tableau</span>
+                <span style={sectionLabel}>Your Tableau</span>
               ) : (
                 <span
                   style={{

--- a/src/components/TableauPanel.tsx
+++ b/src/components/TableauPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import './shared.css'
 import IGameStateView from 'common/IGameStateView'
 import IShip from 'common/IShip'
 import FortGroup from './FortGroup'
@@ -75,14 +76,18 @@ const TableauPanel: React.FC<TableauPanelProps> = ({ view, playerIdx }) => {
                 gap: 8,
                 marginBottom: 8,
               }}>
-              <span
-                style={{
-                  fontWeight: 700,
-                  color: player.color ?? undefined,
-                  fontSize: 15,
-                }}>
-                {player.name}'s Tableau
-              </span>
+              {i === playerIdx ? (
+                <span className="section-label">Your Tableau</span>
+              ) : (
+                <span
+                  style={{
+                    fontWeight: 700,
+                    color: player.color ?? undefined,
+                    fontSize: 15,
+                  }}>
+                  {player.name}'s Tableau
+                </span>
+              )}
               {shipIsHome && <PlayerShip color={player.color} size={24} />}
             </div>
             {/* Forts and ships in one horizontal row */}

--- a/src/components/TableauPanel.tsx
+++ b/src/components/TableauPanel.tsx
@@ -1,12 +1,31 @@
-import React from 'react'
+import React, { useState } from 'react'
 import IGameStateView from 'common/IGameStateView'
+import IShip from 'common/IShip'
 import FortGroup from './FortGroup'
+import Ship from './Ship'
 import { rotateFrom } from 'common/order'
 import PlayerShip from './PlayerShip'
 
 interface TableauPanelProps {
   view: IGameStateView
   playerIdx: number
+}
+
+// Ships highlight individually (forts/buildings highlight as a group); the
+// flex wrapper stretches to the row height so the card matches fort height.
+const ShipCard: React.FC<{ ship: IShip; color?: string }> = ({
+  ship,
+  color,
+}) => {
+  const [hovered, setHovered] = useState(false)
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{ display: 'flex', padding: 6 }}>
+      <Ship ship={ship} highlighted={hovered} fill color={color} />
+    </div>
+  )
 }
 
 const TableauPanel: React.FC<TableauPanelProps> = ({ view, playerIdx }) => {
@@ -62,14 +81,8 @@ const TableauPanel: React.FC<TableauPanelProps> = ({ view, playerIdx }) => {
               </span>
               {shipIsHome && <PlayerShip color={player.color} size={24} />}
             </div>
-            {/* Fort groups */}
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns:
-                  'repeat(auto-fill, minmax(160px, max-content))',
-                gap: 8,
-              }}>
+            {/* Forts and ships in one horizontal row */}
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
               {player.forts.map(fort => {
                 const key = `${idx}:${fort.id}`
                 return (
@@ -78,9 +91,13 @@ const TableauPanel: React.FC<TableauPanelProps> = ({ view, playerIdx }) => {
                     fort={fort}
                     buildings={fort.buildings ?? []}
                     attackingShips={attackingShipsMap[key] ?? []}
+                    color={player.color}
                   />
                 )
               })}
+              {player.ships.map(ship => (
+                <ShipCard key={ship.id} ship={ship} color={player.color} />
+              ))}
             </div>
           </div>
         )

--- a/src/components/TurnBanner.tsx
+++ b/src/components/TurnBanner.tsx
@@ -1,10 +1,4 @@
 import React from 'react'
-import { ALL_CARDS } from 'common/cardRegistry'
-
-interface BuildContext {
-  cardID: string
-  fortID?: string
-}
 
 export interface WaitingForPlayer {
   name: string
@@ -15,28 +9,18 @@ interface TurnBannerProps {
   phase: string
   isMyTurn: boolean
   waitingFor: WaitingForPlayer[]
-  buildContext?: BuildContext
   logOpen: boolean
   onToggleLog: () => void
-}
-
-function buildLabel(ctx: BuildContext, phase: string): string {
-  const cardName = ALL_CARDS.find(c => c.id === ctx.cardID)?.name ?? ctx.cardID
-  if (!ctx.fortID) return `Build ${cardName}`
-  const fortName = ALL_CARDS.find(c => c.id === ctx.fortID)?.name ?? ctx.fortID
-  const prep = phase === 'buildShip' ? 'from' : 'on'
-  return `Build ${cardName} ${prep} ${fortName}`
 }
 
 export const TurnBanner: React.FC<TurnBannerProps> = ({
   phase,
   isMyTurn,
   waitingFor,
-  buildContext,
   logOpen,
   onToggleLog,
 }) => {
-  const phaseLabel = buildContext ? buildLabel(buildContext, phase) : phase
+  const phaseLabel = phase
 
   return (
     <div

--- a/src/components/cardTooltip.ts
+++ b/src/components/cardTooltip.ts
@@ -1,0 +1,24 @@
+import IFort from 'common/IFort'
+import IShip from 'common/IShip'
+import IBuilding from 'common/IBuilding'
+
+function colonists(n: number): string {
+  return `${n} colonist${n === 1 ? '' : 's'}`
+}
+
+// Native hover-tooltip text for the in-play cards: type, colonists, and (for a
+// fort) its attached buildings.
+export function fortTooltip(fort: IFort): string {
+  const buildings = fort.buildings.length
+    ? `Buildings: ${fort.buildings.map(b => b.name).join(', ')}`
+    : 'No buildings'
+  return `Fort\n${colonists(fort.usedSlots)}\n${buildings}`
+}
+
+export function shipTooltip(ship: IShip): string {
+  return `Ship\n${colonists(ship.colonists)}`
+}
+
+export function buildingTooltip(building: IBuilding): string {
+  return `Building\n${colonists(building.colonists)}`
+}

--- a/src/components/cardTooltip.ts
+++ b/src/components/cardTooltip.ts
@@ -1,18 +1,17 @@
 import IFort from 'common/IFort'
 import IShip from 'common/IShip'
 import IBuilding from 'common/IBuilding'
+import { totalColonists } from 'common/fort'
 
 function colonists(n: number): string {
   return `${n} colonist${n === 1 ? '' : 's'}`
 }
 
-// Native hover-tooltip text for the in-play cards: type, colonists, and (for a
-// fort) its attached buildings.
 export function fortTooltip(fort: IFort): string {
   const buildings = fort.buildings.length
     ? `Buildings: ${fort.buildings.map(b => b.name).join(', ')}`
     : 'No buildings'
-  return `Fort\n${colonists(fort.usedSlots)}\n${buildings}`
+  return `Fort\nTotal colonists: ${totalColonists(fort)}\n${buildings}`
 }
 
 export function shipTooltip(ship: IShip): string {

--- a/src/components/pages/GamePage.tsx
+++ b/src/components/pages/GamePage.tsx
@@ -487,7 +487,6 @@ export const GamePage: React.FC = () => {
           playerIdx={playerIdx}
           isMyTurn={isMyTurn}
           waitingFor={waitingFor}
-          buildContext={view.buildContext}
           actionContent={actionContent}
           logOpen={logOpen}
           onToggleLog={onToggleLog}

--- a/src/components/phases/InitPhase.tsx
+++ b/src/components/phases/InitPhase.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import '../shared.css'
+import '../styles.css'
 
 interface InitPhaseProps {
   onJoin: (gameId: string, playerId: string) => void

--- a/src/components/phases/LobbyPhase.tsx
+++ b/src/components/phases/LobbyPhase.tsx
@@ -3,7 +3,7 @@ import IGameStateView from 'common/IGameStateView'
 import { PLAYER_COLORS } from 'common/colors'
 import ColorPicker from 'components/ColorPicker'
 import GameLog from 'components/GameLog'
-import '../shared.css'
+import '../styles.css'
 
 interface LobbyPhaseProps {
   view: IGameStateView

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -80,6 +80,78 @@
   border: 2px solid #007bff;
 }
 
+/* Tableau card — Fort, Ship, Building in play */
+.tableau-card {
+  border: 1px solid #888;
+  border-radius: 6px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+  width: 200px;
+  box-sizing: border-box;
+}
+.tableau-card.highlighted {
+  border-color: #aac;
+  background: #f0f4ff;
+}
+.tableau-card.fill {
+  height: 100%;
+}
+/* Buildings render at full width but half the fort's height, stacked beside it,
+   so they fill the (half-height) wrapper FortGroup gives them. The fort-height
+   alignment min-height isn't needed here — drop it so all content stays visible. */
+.tableau-card.compact {
+  height: 100%;
+  justify-content: space-between;
+}
+.tableau-card.compact .tableau-card-description {
+  min-height: 0;
+  margin-bottom: 0;
+}
+.tableau-card-description {
+  white-space: pre-line;
+  word-break: break-word;
+  font-family: Georgia, serif;
+  font-size: 13px;
+  line-height: 1.35;
+  color: #555;
+  margin-bottom: 6px;
+  text-align: center;
+  min-height: 74px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.tableau-card-grid {
+  margin: 8px 0;
+}
+.tableau-card-cost {
+  font-size: 13px;
+}
+.tableau-card-pips {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+.tableau-card-pip {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid #888;
+  background: #fff;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+/* filled pips overlay a colonist meeple on the empty slot — no fill color */
+
 .fort-grid {
   display: inline-block;
 }

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -1,5 +1,11 @@
 /* Shared styles for all components */
 
+.section-label {
+  font-weight: 600;
+  font-size: 13px;
+  color: #666;
+}
+
 .card {
   border: 2px solid #ccc;
   border-radius: 4px;

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -102,9 +102,6 @@
 .tableau-card.fill {
   height: 100%;
 }
-/* Buildings render at full width but half the fort's height, stacked beside it,
-   so they fill the (half-height) wrapper FortGroup gives them. The fort-height
-   alignment min-height isn't needed here — drop it so all content stays visible. */
 .tableau-card.compact {
   height: 100%;
   justify-content: space-between;
@@ -130,6 +127,25 @@
 .tableau-card-grid {
   margin: 8px 0;
 }
+
+.card-info-popover {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(34, 34, 34, 0.95);
+  color: #fff;
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
+  white-space: pre-line;
+  box-sizing: border-box;
+}
 .tableau-card-cost {
   font-size: 13px;
 }
@@ -150,7 +166,6 @@
   align-items: center;
   justify-content: center;
 }
-/* filled pips overlay a colonist meeple on the empty slot — no fill color */
 
 .fort-grid {
   display: inline-block;

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -172,7 +172,7 @@
 }
 .fort-grid-inner {
   display: grid;
-  gap: 2px;
+  gap: 1px;
 }
 .fort-grid-cell {
   width: 24px;

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -1,11 +1,5 @@
 /* Shared styles for all components */
 
-.section-label {
-  font-weight: 600;
-  font-size: 13px;
-  color: #666;
-}
-
 .card {
   border: 2px solid #ccc;
   border-radius: 4px;

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -1,0 +1,7 @@
+import { CSSProperties } from 'react'
+
+export const sectionLabel: CSSProperties = {
+  fontWeight: 600,
+  fontSize: 13,
+  color: '#666',
+}


### PR DESCRIPTION
Closes #24, #27 

- ships now show on tableau
- build fort/ship/building components shared
- click on tableau cards to show information
- converge styling into `styles.{css/ts}`
- add perimeter outline to forts